### PR TITLE
[FIX] Board blinks after loading a page

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,6 @@ class WordleSolver {
         this.wordList = new WordList(document.getElementById('word-list'));
         this.words = [];
         this.initializeEventListeners();
-        this.hideContainer();
     }
 
     initializeEventListeners() {
@@ -36,10 +35,6 @@ class WordleSolver {
         } catch (error) {
             alert('Error loading word list. Please try again.');
         }
-    }
-
-    hideContainer() {
-        document.querySelector('.container').style.display = 'none';
     }
 
     showContainer() {

--- a/style.css
+++ b/style.css
@@ -24,7 +24,7 @@ body {
 }
 
 .container {
-    display: flex;
+    display: none;
     justify-content: center;
     align-items: flex-start;
     padding: 60px;


### PR DESCRIPTION
After loading page, boards shows up for a moment and dissapears. This was caused by hideContained() method in board constructor. Removed method and changed css to hidden for later to show up when language is choosen.